### PR TITLE
#2 restore module positions when flyout closed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ SOURCES += src/services/MidiDeviceHolder.cpp
 SOURCES += src/services/misc.cpp
 SOURCES += src/services/ModuleBroker.cpp
 SOURCES += src/services/open-file.cpp
+SOURCES += src/services/rack-help.cpp
 SOURCES += src/services/svgtheme.cpp
 SOURCES += src/services/text.cpp
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 CHEM (**C**ontroller for the **H**aken **E**agan **M**atrix) is the successor to **HC One**, which targeted EaganMatrix firmware 10.09.
 CHEM supports EaganMatrix firmware 10.40 and greater.
-Today it is recommended to be running firmware 10.52 on all EaganMatrix devices, but 10.4x should be fine.
+Today it is recommended to be running at least firmware 10.52 on all EaganMatrix devices, but anything 10.40 and later should be fine.
 
 If you've been holding back on updating your Osmose to the latest release, now's the time!
 
@@ -12,14 +12,9 @@ If you've been holding back on updating your Osmose to the latest release, now's
 
 To download the latest build, see the [Nightly Release](https://github.com/Paul-Dempsey/pachde-CHEM/releases/tag/Nightly) page.
 
-When CHEM is released, you will be able to subscribe to the **#d CHEM** plugin in the VCV Rack library.
+When CHEM is released, you will be able to subscribe to the **pachde CHEM** plugin in the VCV Rack library.
 
 Read the [Documentation](./doc/index.md#pachde-chem) for more information on **#d CHEM**.
-
-## Sep 8 2025
-
-All planned features are complete. I am running through my final release checklist.
-If all goes well, I'll submit CHEM to the Rack Library in the next couple of days.
 
 > **Note** –
 > Pachde and **CHEM** are not officially affiliated with or sponsored by Haken Audio.

--- a/TODO.md
+++ b/TODO.md
@@ -17,7 +17,6 @@
 - Factory presets for MidiPad
 - More controllers in Core
 - Save unsaved Play list in patch
-- Shift moved modules back when toggling out of edit mode in XM and Midipad
 - Undo for _Center knobs_ (5) and _Zero modulation_ (0)
 - Kinetic module (shelved for the moment - matrix may not be that useful in Rack scenario)
 - Blinking or highlighted link button when not connected

--- a/src/modules/MidiPad/MidiPad-ui.cpp
+++ b/src/modules/MidiPad/MidiPad-ui.cpp
@@ -398,6 +398,17 @@ void MidiPadUi::refresh()
     }
 }
 
+void MidiPadUi::save_module_positions()
+{
+    fill_right_module_positions(module_positions, this, pad_edit_constants::WIDTH);
+}
+
+void MidiPadUi::restore_module_positions()
+{
+    restore_right_module_positions(module_positions, this);
+    module_positions.clear();
+}
+
 void MidiPadUi::edit_mode(bool editing)
 {
     if (!my_module) return;
@@ -410,10 +421,12 @@ void MidiPadUi::edit_mode(bool editing)
             auto pad = my_module->first_pad();
             edit_id = pad ? pad->id : 0;
         }
+
+        save_module_positions();
+
         float x = box.size.x;
         box.size.x += pad_edit_constants::WIDTH;
         changePanelWidth(dynamic_cast<SvgPanel*>(getPanel()), box.size.x);
-
         APP->scene->rack->setModulePosForce(this, box.pos);
 
         edit_ui = createWidget<PadEdit>(Vec(x, 0));
@@ -432,6 +445,8 @@ void MidiPadUi::edit_mode(bool editing)
         box.size.x = PANEL_WIDTH;
         changePanelWidth(dynamic_cast<SvgPanel*>(getPanel()), PANEL_WIDTH);
         APP->scene->rack->setModulePosForce(this, box.pos);
+
+        restore_module_positions();
     }
 }
 

--- a/src/modules/MidiPad/MidiPad.hpp
+++ b/src/modules/MidiPad/MidiPad.hpp
@@ -4,6 +4,7 @@
 #include "../../services/colors.hpp"
 #include "../../services/em-midi-port.hpp"
 #include "../../services/ModuleBroker.hpp"
+#include "../../services/rack-help.hpp"
 #include "../../widgets/widgets.hpp"
 #include "midi-pad.hpp"
 
@@ -94,13 +95,15 @@ struct MidiPadUi : ChemModuleWidget, IChemClient
     PadWidget* pad_ui[16]{nullptr};
     EditButton* edit_button{nullptr};
     PadEdit* edit_ui{nullptr};
-
+    std::vector<saveModulePos> module_positions;
     int edit_pad{-1};
 
     MidiPadUi(MidiPadModule *module);
 
     bool connected();
     void refresh();
+    void save_module_positions();
+    void restore_module_positions();
     void edit_mode(bool editing);
     void set_edit_pad(int id);
     void on_click_pad(int id);

--- a/src/modules/XM/XM-ui.cpp
+++ b/src/modules/XM/XM-ui.cpp
@@ -708,6 +708,17 @@ Vec XMUi::input_center(int index)
     };
 }
 
+void XMUi::save_module_positions()
+{
+    fill_right_module_positions(module_positions, this, me_constants::WIDTH);
+}
+
+void XMUi::restore_module_positions()
+{
+    restore_right_module_positions(module_positions, this);
+    module_positions.clear();
+}
+
 void XMUi::set_edit_mode(bool edit)
 {
     if (edit) {
@@ -719,6 +730,8 @@ void XMUi::set_edit_mode(bool edit)
             wire_frame = createWidget<EditWireframe>(Vec(0,0));
             wire_frame->set_ui(this);
             addChild(wire_frame);
+
+            save_module_positions();
             box.size.x += me_constants::WIDTH;
             APP->scene->rack->setModulePosForce(this, box.pos);
         }
@@ -735,8 +748,11 @@ void XMUi::set_edit_mode(bool edit)
             wire_frame = nullptr;
         }
         update_main_ui(theme_engine.getTheme(getThemeName()));
+
         box.size.x = PANEL_WIDTH;
         APP->scene->rack->setModulePosForce(this, box.pos);
+        restore_module_positions();
+
         if (my_module && my_module->overlay) {
             my_module->overlay->overlay_client_pause(my_module, false);
         }

--- a/src/modules/XM/XM.hpp
+++ b/src/modules/XM/XM.hpp
@@ -5,6 +5,7 @@
 #include "../../services/color-help.hpp"
 #include "../../services/em-midi-port.hpp"
 #include "../../services/ModuleBroker.hpp"
+#include "../../services/rack-help.hpp"
 #include "../../widgets/widgets.hpp"
 #include "../XM-shared/macro-data.hpp"
 #include "../XM-shared/xm-overlay.hpp"
@@ -116,6 +117,7 @@ struct XMUi : ChemModuleWidget
     TextLabel * title{nullptr};
     MacroEdit * edit_macro{nullptr};
     EditWireframe * wire_frame{nullptr};
+    std::vector<saveModulePos> module_positions;
 
     TrimPot * knobs[9]{nullptr};
     TrackWidget * tracks[8]{nullptr};
@@ -137,6 +139,8 @@ struct XMUi : ChemModuleWidget
     IOverlay* get_overlay() { return my_module ? my_module->get_overlay() : nullptr; }
     Vec knob_center(int index);
     Vec input_center(int index);
+    void save_module_positions();
+    void restore_module_positions();
     void set_edit_mode(bool edit);
     void set_edit_item(int index);
     void commit_macro();

--- a/src/services/rack-help.cpp
+++ b/src/services/rack-help.cpp
@@ -1,0 +1,50 @@
+#include "rack-help.hpp"
+
+namespace pachde {
+
+bool lrtb_widget_sort(const Widget* a, const Widget* b) {
+    if (a->box.pos.y < b->box.pos.y) return true;
+    if (a->box.pos.y > b->box.pos.y) return false;
+    return a->box.pos.x < b->box.pos.x;
+}
+
+
+
+void fill_right_module_positions(std::vector<saveModulePos>& module_positions, ModuleWidget* this_widget, float extra)
+{
+    module_positions.clear();
+    std::vector<ModuleWidget*> module_widgets = APP->scene->rack->getModules();
+    std::sort(module_widgets.begin(), module_widgets.end(), lrtb_widget_sort);
+    for (auto m: module_widgets) {
+        if (m->box.pos.y < this_widget->box.pos.y) continue;
+        if (m->box.pos.y > this_widget->box.pos.y) break;
+        // module is to the right in the same row
+        if (m->box.pos.x > this_widget->box.pos.x) {
+            if (module_positions.empty()) { // first module to the right
+                if (m->box.pos.x > (this_widget->box.pos.x + this_widget->box.size.x + extra)) {
+                    // There's room for the flyout, so nothing to restore
+                    return;
+                }
+            }
+            module_positions.push_back(saveModulePos{m, m->box.pos});
+        }
+    }
+}
+
+void restore_right_module_positions(std::vector<saveModulePos>& module_positions, ModuleWidget* this_widget)
+{
+    if (module_positions.empty()) return;
+    std::vector<ModuleWidget*> module_widgets = APP->scene->rack->getModules();
+    std::sort(module_widgets.begin(), module_widgets.end(), lrtb_widget_sort);
+    for (auto m: module_widgets) {
+        auto it = std::find_if(module_positions.cbegin(), module_positions.cend(), [m](const saveModulePos& smp) {
+            return smp.module_widget == m;
+        });
+        if (it != module_positions.cend()) {
+            APP->scene->rack->setModulePosForce(m, (*it).saved_pos);
+        }
+    }
+}
+
+
+}

--- a/src/services/rack-help.hpp
+++ b/src/services/rack-help.hpp
@@ -29,4 +29,19 @@ inline ParamQuantity* snap(ParamQuantity* p) {
     return p;
 }
 
+// sort fn for widgets in left-to-right, top-to-bottom order.
+bool lrtb_widget_sort(const Widget* a, const Widget* b);
+
+struct saveModulePos {
+    ModuleWidget* module_widget;
+    Vec saved_pos;
+};
+
+// collect the positions of all mopdules to the right of modwidget.
+// if there is more than 'extra' space to the immediate right of modwidget,
+// module_positiosn will be empty
+void fill_right_module_positions(std::vector<saveModulePos>& module_positions, ModuleWidget* this_widget, float extra);
+
+void restore_right_module_positions(std::vector<saveModulePos>& module_positions, ModuleWidget* this_widget);
+
 }


### PR DESCRIPTION
Implement save/restore of module positions to the right of the MidiPad and XM editing flyouts.